### PR TITLE
fix: disable vercel image optimization to save resources

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next';
 import path from 'path';
 
 const nextConfig: NextConfig = {
+  images: { unoptimized: true },
   webpack: (config) => {
     config.resolve.alias['@tiptap/core'] = path.resolve(__dirname, 'node_modules/@tiptap/core');
 


### PR DESCRIPTION
## Summary
- Set `images.unoptimized` to `true` in Next.js config so `next/image` serves original sources instead of Vercel Image Optimization to save resources.